### PR TITLE
Docs: Update README package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This section is auto-generated. Do not edit manually.
 | --- | --- | --- |
 | `beatoraja` | [0.8.8](https://github.com/MiyakoMeow/nur-packages/blob/main/pkgs/by-name/be/beatoraja/package.nix) | [🏠Homepage](https://www.mocha-repository.info/download.php) A modern BMS Player |
 | `clang-minimal` | [19.1.7](https://github.com/MiyakoMeow/nur-packages/blob/main/pkgs/by-name/cl/clang-minimal/package.nix) | [🏠Homepage](https://clang.llvm.org/) C language family frontend for LLVM (wrapper script) |
+| `continue-cli` | [1.4.45](https://github.com/MiyakoMeow/nur-packages/blob/main/pkgs/by-name/co/continue-cli/package.nix) | [🏠Homepage](https://continue.dev) Continue CLI |
 | `fcitx5-pinyin-moegirl` | [20250309](https://github.com/MiyakoMeow/nur-packages/blob/main/pkgs/by-name/fc/fcitx5-pinyin-moegirl/package.nix) | [🏠Homepage](https://github.com/outloudvi/mw2fcitx) Fcitx 5 pinyin dictionary generator for MediaWiki instances. Releases for dict of zh.moegirl.org.cn. (auto update) |
 | `fcitx5-pinyin-zhwiki` | [0.2.5](https://github.com/MiyakoMeow/nur-packages/blob/main/pkgs/by-name/fc/fcitx5-pinyin-zhwiki/package.nix) | [🏠Homepage](https://github.com/felixonmars/fcitx5-pinyin-zhwiki) Fcitx 5 Pinyin Dictionary from zh.wikipedia.org (auto update) |
 | `free-download-manager` | [6.30.0.6459](https://github.com/MiyakoMeow/nur-packages/blob/main/pkgs/by-name/fr/free-download-manager/package.nix) | [🏠Homepage](https://www.freedownloadmanager.org/) FDM is a powerful modern download accelerator and organizer. |


### PR DESCRIPTION
由 GitHub Actions 自动更新 README 的 Package List

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `continue-cli` (v1.4.45) to the README’s auto-generated by-name package list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b5835302433621e91e5147cf318bc6fc4ee1948. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->